### PR TITLE
Fix file download

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ This will cause file downloads to automatically download into the `download_loca
 requiring a confirmation dialog. You might need to sleep the handler until the file is downloaded
 since this occurs asynchronously.
 
+In order to download a file from a link that opens in a new tab (i.e. `target='_blank'`) you will need to 
+call `enable_download_in_headless_chrome` in your scraping script after navigating to the desired page, but before
+clicking to download. This will replace all `target='_blank'` with `target='_self'`. For example:
+
+```python
+# Navigate to download page
+driver._driver.find_element_by_xpath('//a[@href="/downloads/"]').click()
+# Enable headless chrome file download
+driver.enable_download_in_headless_chrome()
+# Click the download link
+driver._driver.find_element_by_class_name("btn").click()
+```
+
 ## Building and uploading the distributable package
 
 Everything is summarized into a simple Makefile so use:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ Have a look at the example in `lambda_function.py`: it looks up “21 buttons”
 
 Run it with: `make docker-run`
 
+#### Downloading files
+
+If your goal is to use selenium to download files instead of just scraping content from web pages, then
+you will need to specify a `download_dir` when initializing the WebDriverWrapper. Your download location 
+should be a writable Lambda directory such as `/tmp`. For example, the first code in 
+`lambda_handler` would become 
+
+```python
+driver = WebDriverWrapper(download_location='/tmp')
+```
+
+This will cause file downloads to automatically download into the `download_location` without 
+requiring a confirmation dialog. You might need to sleep the handler until the file is downloaded
+since this occurs asynchronously.
+
 ## Building and uploading the distributable package
 
 Everything is summarized into a simple Makefile so use:


### PR DESCRIPTION
First pass at adding a fix for downloading files with headless chrome. Closes #12 

Still to do:

- [x] Add documentation

Also, the following line is necessary to download a file from a link that opens in a new tab (i.e. `target='_blank'` but I am not 100% sure if it breaks anything in general. 

https://github.com/21Buttons/pychromeless/blob/cb95ddec34693ca24be0db070f8c5a04610639b0/src/webdriver_wrapper.py#L106-L107

In my usage, `enable_download_in_headless_chrome` gets called during the constructor by default, but I all it again in my scraping script after navigating to the desired page in order to replace all the `target='_blank'` with `target='_self'` 

For example:

```python
# Navigate to report download page
driver._driver.find_element_by_xpath('//a[@href="/secure/reports/"]').click()
# Enable headless chrome file download
driver.enable_download_in_headless_chrome()
# Click the download link
driver._driver.find_element_by_class_name("btn-info").click()
```