### PR TITLE
Changes to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 selenium==2.53.0
-chromedriver-installer==0.0.6
+chromedriver-binary==2.37.0


### PR DESCRIPTION
Changed the chromedriver installer from `chromedriver-installer==0.0.6` to **`chromedriver-binary==2.37.0 `** since` chromedriver-binary` is more up to date with the latest chromedriver.
### As stated in this pull request:

### [Remove chromedriver-installer, use chromedriver-binary](https://github.com/ONSdigital/sdc-responses-dashboard/pull/68)

